### PR TITLE
fix: mf to glom strategy

### DIFF
--- a/cerebellar_models/analysis/plots.py
+++ b/cerebellar_models/analysis/plots.py
@@ -139,7 +139,7 @@ class Plot(abc.ABC):
             self.update()
         self.is_plotted = True
 
-    def show(self):  # pragma:nocover
+    def show(self):  # pragma: nocover
         """
         Show the figure.
         The figure will be plotted if needed.

--- a/cerebellar_models/analysis/report.py
+++ b/cerebellar_models/analysis/report.py
@@ -130,14 +130,14 @@ class Report:
         if plot_name in self.plots:
             self.plots[plot_name].save_figure(output_name, dpi, pad, **kwargs)
 
-    def show_plot(self, plot_name):  # pragma:nocover
+    def show_plot(self, plot_name):  # pragma: nocover
         """
         Show one of the report's plots.
         """
         if plot_name in self.plots:
             self.plots[plot_name].show()
 
-    def show(self):  # pragma:nocover
+    def show(self):  # pragma: nocover
         """
         Show all report's plots one by one.
         """

--- a/cerebellar_models/cli.py
+++ b/cerebellar_models/cli.py
@@ -71,7 +71,7 @@ class CerebOption:
         self.type = type_term
         """Type of the option"""
 
-    def get_widget(self):  # pragma: no cover
+    def get_widget(self):  # pragma: nocover
         """
         Return the survey widget for this option
         """
@@ -107,7 +107,7 @@ class MicrozonesParams:
         """Duplicated connections obtained from the cell type labelling"""
 
 
-def print_panel(options, title="Configure your cerebellum circuit."):  # pragma: no cover
+def print_panel(options, title="Configure your cerebellum circuit."):  # pragma: nocover
     """
     Print a survey form based on a list of options.
     The result of the form will be saved in its options.
@@ -131,7 +131,7 @@ def print_panel(options, title="Configure your cerebellum circuit."):  # pragma:
 
 @click.group(help="Cerebellar models CLI")
 @click.version_option(__version__)
-def app():  # pragma: no cover
+def app():  # pragma: nocover
     """The main CLI entry point"""
     pass
 
@@ -461,7 +461,7 @@ def _write_config(configuration, output_folder, extension):
             content = f.read()
             template = json.loads(content, object_pairs_hook=OrderedDict)
         configuration = deep_order(configuration.__tree__(), template)
-    except ConfigurationError as e:  # pragma: no cover
+    except ConfigurationError as e:  # pragma: nocover
         raise ValueError("A BSB error happened when loading your cerebellar circuit") from e
     if extension == "yaml":
         yaml.add_representer(
@@ -611,11 +611,11 @@ def configure(
                 )
                 deep_update(configuration["simulations"][simulation_name]["devices"], default_stim)
                 sim_choices[simulation_name] = sim_choices[sim_name]
-            else:  # pragma: no cover
+            else:  # pragma: nocover
                 raise ValueError(
                     f"Only nest configurations are implemented. Provided simulator: {simulator}"
                 )
-    else:  # pragma: no cover
+    else:  # pragma: nocover
         raise ValueError(f"Only mouse configuration are implemented. Provided species: {species}")
 
     # Step 7: Recap choices

--- a/cerebellar_models/connectome/to_glomerulus.py
+++ b/cerebellar_models/connectome/to_glomerulus.py
@@ -43,16 +43,15 @@ class ConnectomeGlomerulus(InvertedRoI, ConnectionStrategy):
                 post_locs = np.full((n_glom, 3), -1, dtype=int)
 
                 # We connect each glomerulus to a presynaptic cell.
-                to_keep = 0
                 for j, glomerulus in enumerate(glomeruli_pos):
                     pre_ids = self.pre_selection(presyn_pos, glomerulus)
                     if len(pre_ids) > 0:
-                        roll = int(np.floor(len(pre_ids) * norm_exp_dist()[0]))
-                        pre_locs[to_keep, 0] = pre_ids[roll]
-                        post_locs[to_keep, 0] = j
-                        to_keep += 1
-
-                self.connect_cells(pre_ps, post_ps, pre_locs[:to_keep], post_locs[:to_keep])
+                        pre_locs[j, 0] = pre_ids[int(np.floor(len(pre_ids) * norm_exp_dist()[0]))]
+                    else:
+                        # if there is no presyn within the box use the closest one
+                        pre_locs[j, 0] = np.argmin(np.linalg.norm(presyn_pos - glomerulus, axis=1))
+                    post_locs[j, 0] = j
+                self.connect_cells(pre_ps, post_ps, pre_locs, post_locs)
 
     @abc.abstractmethod
     def pre_selection(

--- a/cerebellar_models/connectome/to_glomerulus.py
+++ b/cerebellar_models/connectome/to_glomerulus.py
@@ -93,24 +93,6 @@ class ConnectomeMossyGlomerulus(ConnectomeGlomerulus):
         dist = np.linalg.norm(diff[ids_to_keep], axis=1)
         return ids_to_keep[np.argsort(dist)]
 
-    def get_region_of_interest(self, chunk):
-        # Chunk here is a postsynaptic chunk because of InvertedRoI
-        # We look for chunks containing mossy fibers that are within a rectangle of size
-        # x_length * y_length centered on the postsynaptic chunk containing the glomerulus.
-        chunks = set(
-            itertools.chain.from_iterable(
-                ct.get_placement_set().get_all_chunks() for ct in self.presynaptic.cell_types
-            )
-        )
-        selected_chunks = []
-        for c in chunks:
-            x_dist = np.fabs(chunk[0] - c[0]) * chunk.dimensions[0]
-            y_dist = np.fabs(chunk[1] - c[1]) * chunk.dimensions[1]
-
-            if (x_dist < self.x_length / 2) and (y_dist < self.y_length / 2):
-                selected_chunks.append(Chunk([c[0], c[1], c[2]], chunk.dimensions))
-        return selected_chunks
-
 
 @config.node
 class ConnectomeUBCGlomerulus(ConnectomeGlomerulus, PresynDistStrat):

--- a/cerebellar_models/connectome/to_glomerulus.py
+++ b/cerebellar_models/connectome/to_glomerulus.py
@@ -58,7 +58,7 @@ class ConnectomeGlomerulus(InvertedRoI, ConnectionStrategy):
         self,
         presyn_pos,
         glom_pos,
-    ):  # pragma: no cover
+    ):  # pragma: nocover
         """
         Order presynaptic cell ids based on their respective distance to glomerulus
 

--- a/docs/strategies/connection-strategies.rst
+++ b/docs/strategies/connection-strategies.rst
@@ -8,7 +8,8 @@ Connection strategies
 
 The algorithm selects one mossy fiber within the :math:`x\_length \times y\_length \times z\_size` :math:`\mu m` box
 surrounding each glomerulus. Here ``z_size`` is the size of the partition where the glomeruli are (i.e. no limit).
-This selection is random and performed with a truncated exponential distribution.
+This selection is random and performed with a truncated exponential distribution. If no mossy_fiber could be found
+in the box surrounding one glomerulus, the closest mossy_fiber is chosen.
 
 * ``x_length``: Length of the box along the x axis surrounding the glomerulus in which the mossy fiber can be connected.
 
@@ -151,7 +152,8 @@ See bsb :doc:`documentation <bsb:connectivity/connection-strategies>`.
 :class:`ConnectomeUBCGlomerulus <.connectome.to_glomerulus.ConnectomeUBCGlomerulus>`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 The algorithm selects one UBC within the sphere surrounding each UBC glomerulus. This selection is random and performed
-with a truncated exponential distribution.
+with a truncated exponential distribution. If no UBC could be found within the sphere surrounding one UBC glomerulus,
+the closest UBC is chosen.
 
 * ``radius``: Radius of the sphere to filter the UBC within it.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,14 @@ known_third_party = ["nest"]
 [project.entry-points."bsb.components"]
 my_components = "cerebellar_models:classmap"
 
+[tool.coverage.run]
+branch = true
+source = ["cerebellar_models"]
+
+[tool.coverage.report]
+exclude_lines = [ "if typing.TYPE_CHECKING:", "pragma: nocover" ]
+show_missing = true
+
 [tool.bumpversion]
 current_version = "0.11.0"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"

--- a/tests/test_structure_analysis.py
+++ b/tests/test_structure_analysis.py
@@ -167,7 +167,7 @@ class TestConnectivityPlots(
             self.assertAll(np.array(self.plot.get_convergences()[k]) == 1.0)
         divergences = self.plot.get_divergences()["mf to glomerulus"]
         self.assertEqual(len(divergences), len(self.scaffold.get_placement_set("mossy_fibers")))
-        self.assertAlmostEqual(np.mean(divergences), 20.0, delta=0.5)
+        self.assertAlmostEqual(np.mean(divergences), 20.0, delta=1.0)
 
     def test_warn(self):
         # No connection sets in storage before compile

--- a/tests/test_to_glomerulus.py
+++ b/tests/test_to_glomerulus.py
@@ -15,6 +15,72 @@ from bsb_test import (
 )
 
 
+def _test_fallback_to_closest_presyn(self, conn_name, strategy, extra_params):
+    """
+    Shared helper: place one glomerulus (test_cell) and two pre cells whose positions are
+    ALL outside the geometric ROI.  After compiling, every glomerulus must be connected and
+    the connected pre cell must be the closest one (fallback branch).
+
+    The chunk size is pinned to 100 so all three positions sit in chunk (0,0,0) and are
+    therefore loaded together during connect(), ensuring presyn_pos is never empty.
+    """
+    chunk_size = 100.0
+    glom_pos = np.array([[50.0, 50.0, 50.0]])
+    # Both pre cells are at x-distance 40 and 45 from the glomerulus.
+    # With the small ROIs used by the callers (x_length=5 or radius=5) they are
+    # intentionally outside the selection region, triggering the fallback.
+    pre_close = np.array([90.0, 50.0, 50.0])
+    pre_far = np.array([95.0, 50.0, 50.0])
+
+    # Pin chunk size and override the single glomerulus position.
+    self.cfg.network.chunk_size = chunk_size
+    self.cfg.cell_types["test_cell"].spatial.count = 1
+    self.cfg.placement.ch4_c25.positions = MPI.bcast(glom_pos)
+
+    # Add a separate pre cell type with fixed positions.
+    self.cfg.cell_types.add("pre_cell", dict(spatial=dict(radius=2.5, count=2)))
+    self.cfg.placement.add(
+        "place_pre",
+        dict(
+            strategy="bsb.placement.strategy.FixedPositions",
+            partitions=[],
+            cell_types=["pre_cell"],
+        ),
+    )
+    self.cfg.placement["place_pre"].positions = MPI.bcast(np.vstack([pre_close, pre_far]))
+
+    # Add the connectivity rule under test.
+    self.cfg.connectivity.add(
+        conn_name,
+        dict(
+            strategy=strategy,
+            presynaptic=dict(cell_types=["pre_cell"]),
+            postsynaptic=dict(cell_types=["test_cell"]),
+            **extra_params,
+        ),
+    )
+    self.network = Scaffold(self.cfg, self.storage)
+    self.network.compile(clear=True)
+
+    cs = self.network.get_connectivity_set(conn_name)
+    pre_positions = self.network.get_placement_set("pre_cell").load_positions()
+
+    # Every glomerulus must receive a connection via the fallback.
+    self.assertEqual(len(cs), 1, "Glomerulus must be connected even when no pre cell is in the ROI")
+
+    for from_, to_ in cs.load_connections().as_globals():
+        connected_pre_pos = pre_positions[from_[0]]
+        # The fallback must select the geometrically closest pre cell.
+        expected_closest = pre_positions[
+            np.argmin(np.linalg.norm(pre_positions - glom_pos[0], axis=1))
+        ]
+        self.assertClose(
+            connected_pre_pos,
+            expected_closest,
+            "Closest presynaptic cell must be selected as the fallback target",
+        )
+
+
 def _test_distance_to_glomerulus(self, nb_trials=50):
     # Override positions
     self.chunk_size = 100.0
@@ -95,6 +161,16 @@ class TestConnectomeMossyGlomerulus(
     def test_distance(self):
         _test_distance_to_glomerulus(self)
 
+    def test_fallback_to_closest_when_no_presyn_in_roi(self):
+        """When no mossy fiber is within the x/y box, the closest one is connected."""
+        _test_fallback_to_closest_presyn(
+            self,
+            conn_name="mf_to_glom",
+            strategy="cerebellar_models.connectome.to_glomerulus.ConnectomeMossyGlomerulus",
+            # x_length=5: both pre cells are at x-distance 40 and 45 → outside the box.
+            extra_params={"x_length": 5, "y_length": 5},
+        )
+
 
 class TestConnectomeUBCGlomerulus(
     RandomStorageFixture,
@@ -136,3 +212,13 @@ class TestConnectomeUBCGlomerulus(
 
     def test_distance(self):
         _test_distance_to_glomerulus(self)
+
+    def test_fallback_to_closest_when_no_presyn_in_roi(self):
+        """When no UBC is within the sphere, the closest one is connected."""
+        _test_fallback_to_closest_presyn(
+            self,
+            conn_name="ubc_to_glom",
+            strategy="cerebellar_models.connectome.to_glomerulus.ConnectomeUBCGlomerulus",
+            # radius=5: both pre cells are at distance 40 and 45 → outside the sphere.
+            extra_params={"radius": 5},
+        )

--- a/tests/test_to_glomerulus.py
+++ b/tests/test_to_glomerulus.py
@@ -7,7 +7,6 @@ import unittest
 import numpy as np
 from bsb import Scaffold
 from bsb_test import (
-    MPI,
     FixedPosConfigFixture,
     NetworkFixture,
     NumpyTestCase,
@@ -35,7 +34,7 @@ def _test_fallback_to_closest_presyn(self, conn_name, strategy, extra_params):
     # Pin chunk size and override the single glomerulus position.
     self.cfg.network.chunk_size = chunk_size
     self.cfg.cell_types["test_cell"].spatial.count = 1
-    self.cfg.placement.ch4_c25.positions = MPI.bcast(glom_pos)
+    self.cfg.placement.ch4_c25.positions = glom_pos
 
     # Add a separate pre cell type with fixed positions.
     self.cfg.cell_types.add("pre_cell", dict(spatial=dict(radius=2.5, count=2)))
@@ -47,7 +46,7 @@ def _test_fallback_to_closest_presyn(self, conn_name, strategy, extra_params):
             cell_types=["pre_cell"],
         ),
     )
-    self.cfg.placement["place_pre"].positions = MPI.bcast(np.vstack([pre_close, pre_far]))
+    self.cfg.placement["place_pre"].positions = np.vstack([pre_close, pre_far])
 
     # Add the connectivity rule under test.
     self.cfg.connectivity.add(
@@ -89,7 +88,7 @@ def _test_distance_to_glomerulus(self, nb_trials=50):
     pos_3 = np.array([0.5, 1.0, 0.5]) * self.chunk_size  # too far away
     self.cfg.network.chunk_size = self.chunk_size
     self.cfg.cell_types["test_cell"].spatial.count = 3
-    self.cfg.placement.ch4_c25.positions = MPI.bcast(np.vstack((pos_1, pos_2, pos_3)))
+    self.cfg.placement.ch4_c25.positions = np.vstack((pos_1, pos_2, pos_3))
     self.network = Scaffold(self.cfg, self.storage)
 
     sources = np.full(nb_trials, -1)


### PR DESCRIPTION
## Describe the work done
- Add fallback to `ConnectomeGlomerulus` to select the glosest presyn when none is found with the `pre_selection`.
- Fix coverage targets and `pragma: no cover` instances

## Tasks

* [x] Added tests
* [x] Updated documentation

<!-- readthedocs-preview cerebellar-models start -->
----
📚 Documentation preview 📚: https://cerebellar-models--75.org.readthedocs.build/en/75/

<!-- readthedocs-preview cerebellar-models end -->