### PR TITLE
Fix/io_molecular_hemitype

### DIFF
--- a/cerebellar_models/connectome/io_molecular.py
+++ b/cerebellar_models/connectome/io_molecular.py
@@ -40,7 +40,7 @@ class ConnectomeIO_MLI(NotParallel, ConnectionStrategy):
         found_post = np.full(len(self.postsynaptic.cell_types), False)
         for strat in self.mli_pc_connectivity:
             post_ct = strat.postsynaptic.cell_types
-            if len(post_ct) != 1 or post_ct[0] != self.pre_cell_pc:
+            if len(post_ct) != 1 or post_ct[0] not in self.pre_cell_pc.cell_types:
                 raise ConfigurationError(
                     f"PC cell type of the MLI to PC dependency rule does not correspond "
                     f"to the provided PC type for strat {strat.name}"
@@ -58,7 +58,7 @@ class ConnectomeIO_MLI(NotParallel, ConnectionStrategy):
             )
         for strat in self.io_pc_connectivity:
             post_ct = strat.postsynaptic.cell_types
-            if len(post_ct) != 1 or post_ct[0] != self.pre_cell_pc:
+            if len(post_ct) != 1 or post_ct[0] not in self.pre_cell_pc.cell_types:
                 raise ConfigurationError(
                     f"PC cell type of the IO to PC dependency rule does not correspond "
                     f"to the provided PC type for strategy {strat.name}"
@@ -83,7 +83,7 @@ class ConnectomeIO_MLI(NotParallel, ConnectionStrategy):
                 - an array of the presynaptic cell_type connection locations,
                 - an array of the postsynaptic pc connection locations
         """
-        cs = connection_strat.get_output_names(cell_type, self.pre_cell_pc)
+        cs = connection_strat.get_output_names(cell_type, self.pre_cell_pc.cell_types[0])
         assert (
             len(cs) == 1
         ), f"Only one connection set should be given from {connection_strat.name}."

--- a/cerebellar_models/connectome/io_molecular.py
+++ b/cerebellar_models/connectome/io_molecular.py
@@ -3,7 +3,7 @@ Module for the configuration node of the IO to molecular layer interneurons (MLI
 """
 
 import numpy as np
-from bsb import ConfigurationError, ConnectionStrategy, config, refs
+from bsb import ConfigurationError, ConnectionStrategy, config, Hemitype, refs
 from bsb.mixins import NotParallel
 
 
@@ -18,7 +18,7 @@ class ConnectomeIO_MLI(NotParallel, ConnectionStrategy):
     """Connection Strategy that links IO to PC."""
     mli_pc_connectivity = config.reflist(refs.connectivity_ref, required=True)
     """List of Connection Strategies that links MLI to PC."""
-    pre_cell_pc = config.ref(refs.cell_type_ref, required=True)
+    pre_cell_pc = config.attr(type=Hemitype, required=True)
     """Celltype used for to represent PC."""
     depends_on: list[ConnectionStrategy] = config.reflist(refs.connectivity_ref)
 


### PR DESCRIPTION
Hi. I modified the `pre_cell_pc `declaration (and related type-dependent functions) since the current version raises an error related to the PC labels. With this fix the network compiles correctly.
@Geenetto