### PR TITLE
fix: make cerebellar-models work outside of the cloned repo context

### DIFF
--- a/cerebellar_models/cli.py
+++ b/cerebellar_models/cli.py
@@ -534,6 +534,28 @@ def _clear_unnecessary_params(configuration):
     return configuration
 
 
+def _absolutize_morphology_paths(configuration):
+    """
+    Resolve every morphology source file to an absolute path, in place.
+
+    Morphology file paths in the canonical configurations are relative to
+    ``cerebellar_models``' own package folder (e.g. ``./morphologies/GranuleCell.swc``).
+    BSB resolves such relative paths against the current working directory at compile
+    time, so left as-is they would only work if ``bsb compile``/``bsb simulate`` happens
+    to be run from that exact folder. Making them absolute here lets the generated
+    configuration file be compiled from anywhere.
+
+    :param dict configuration: BSB configuration tree.
+    :rtype: dict
+    """
+    base_folder = os.path.dirname(CONFIGURATION_FOLDER)
+    for morphology in configuration.get("morphologies", []):
+        path = morphology.get("file")
+        if path and not os.path.isabs(path) and "://" not in path:
+            morphology["file"] = os.path.normpath(join(base_folder, path))
+    return configuration
+
+
 def _write_config(configuration, output_folder, extension, non_interactive=False):
     output_options = []
     if output_folder is None:
@@ -727,7 +749,11 @@ def configure(
     # Step 5: remove unnecessary cells and connections
     configuration = _clear_unnecessary_params(configuration)
 
-    # Step 6: Recap choices
+    # Step 6: absolutize morphology file paths so the configuration can be compiled
+    # from any working directory
+    configuration = _absolutize_morphology_paths(configuration)
+
+    # Step 7: Recap choices
     print("\n\nYour choices are:")
     print(f"Species: {species}")
     print(f"State: {state}")
@@ -742,5 +768,5 @@ def configure(
         print(f"\t\tCell model: {choices[0]}")
         print(f"\t\tSynapse model: {choices[1]}")
     print("----------------------------\n")
-    # Step 7: output folder and extension
+    # Step 8: output folder and extension
     _write_config(configuration, output_folder, extension, non_interactive=non_interactive)

--- a/cerebellar_models/cli.py
+++ b/cerebellar_models/cli.py
@@ -3,7 +3,8 @@ import json
 import os
 from collections import OrderedDict
 from enum import Enum
-from os.path import abspath, dirname, join
+from os.path import abspath, join
+from pathlib import Path
 
 import click
 import numpy as np
@@ -23,8 +24,35 @@ from cerebellar_models.utils import (
     load_configs_in_folder,
 )
 
-ROOT_FOLDER = dirname(dirname(abspath(__file__)))
-CONFIGURATION_FOLDER = join(ROOT_FOLDER, "configurations")
+# `configurations/`, `morphologies/` and the JSON template below are bundled inside
+# `cerebellar_models/` for regular installs (see `force-include` in pyproject.toml),
+# but for editable/development installs they stay at their original location in the
+# repository, next to (or above) the package. Both locations are checked so the CLI
+# works the same way whether cerebellar-models was pip-installed or checked out.
+PACKAGE_FOLDER = Path(__file__).resolve().parent
+REPO_ROOT_FOLDER = PACKAGE_FOLDER.parent
+
+
+def _find_bundled_path(installed_relpath: str, source_relpath: str) -> str:
+    """
+    Locate a resource that is bundled inside the installed package, falling back
+    to its original path in a source/editable checkout.
+
+    :param str installed_relpath: path of the resource relative to the
+        ``cerebellar_models`` package directory, as shipped in the built wheel.
+    :param str source_relpath: path of the resource relative to the repository
+        root, as found in a source checkout or editable install.
+    :rtype: str
+    """
+    for candidate in (PACKAGE_FOLDER / installed_relpath, REPO_ROOT_FOLDER / source_relpath):
+        if candidate.exists():
+            return str(candidate)
+    raise FileNotFoundError(
+        f"Could not locate the '{source_relpath}' resource bundled with cerebellar_models."
+    )
+
+
+CONFIGURATION_FOLDER = _find_bundled_path("configurations", "configurations")
 
 
 class TypeTermElem(Enum):
@@ -517,9 +545,11 @@ def _write_config(configuration, output_folder, extension):
     filename = os.path.join(output_folder, f"circuit.{extension}")
     try:
         configuration = Configuration.default(**configuration)  # Check that the configuration works
-        with open(
-            join(ROOT_FOLDER, "tests", "test_configurations", "canonical_mouse_awake_io_nest.json")
-        ) as f:
+        template_path = _find_bundled_path(
+            join("configurations", "canonical_mouse_awake_io_nest.json"),
+            join("tests", "test_configurations", "canonical_mouse_awake_io_nest.json"),
+        )
+        with open(template_path) as f:
             content = f.read()
             template = json.loads(content, object_pairs_hook=OrderedDict)
         configuration = deep_order(configuration.__tree__(), template)

--- a/cerebellar_models/cli.py
+++ b/cerebellar_models/cli.py
@@ -56,7 +56,7 @@ def _find_bundled_path(installed_relpath: str, source_relpath: str) -> str:
             return str(candidate)
     raise FileNotFoundError(
         f"Could not locate the '{source_relpath}' resource bundled with cerebellar_models."
-    )
+    )  # pragma: nocover
 
 
 CONFIGURATION_FOLDER = _find_bundled_path("configurations", "configurations")

--- a/cerebellar_models/cli.py
+++ b/cerebellar_models/cli.py
@@ -142,14 +142,20 @@ class MicrozonesParams:
         """Duplicated connections obtained from the cell type labelling"""
 
 
-def print_panel(options, title="Configure your cerebellum circuit."):  # pragma: nocover
+def print_panel(
+    options, title="Configure your cerebellum circuit.", non_interactive=False
+):  # pragma: nocover
     """
     Print a survey form based on a list of options.
     The result of the form will be saved in its options.
 
     :param list[CerebOption] options: List of options to display
     :param str title: Title to display on top of the form
+    :param bool non_interactive: If True, skip the survey entirely and keep each option's
+        already-computed default value (see ``CerebOption.__init__``).
     """
+    if non_interactive:
+        return
     import survey
 
     form = survey.routines.form(
@@ -178,7 +184,7 @@ AVAILABLE_SPECIES = click.Choice(get_folders_in_folder(CONFIGURATION_FOLDER), ca
 AVAILABLE_EXTENSIONS = click.Choice(["yaml", "json"], case_sensitive=True)
 
 
-def _configure_species(species):
+def _configure_species(species, non_interactive=False):
     main_options = [
         CerebOption(
             "Species",
@@ -187,11 +193,15 @@ def _configure_species(species):
             species,
         ),
     ]
-    print_panel(main_options, "Select your configuration's species")
+    print_panel(
+        main_options, "Select your configuration's species", non_interactive=non_interactive
+    )
     return main_options[0].value
 
 
-def _configure_cell_types(species_folder, config_cell_types, add_microzones: bool):
+def _configure_cell_types(
+    species_folder, config_cell_types, add_microzones: bool, non_interactive=False
+):
     cell_type_names = []
     for filename1, config_1 in config_cell_types.items():
         cell_types1 = list(config_1["cell_types"].keys())
@@ -226,7 +236,9 @@ def _configure_cell_types(species_folder, config_cell_types, add_microzones: boo
         ),
     ]
     print_panel(
-        species_options, "Select the state of the subject and the cell types to add in the circuit"
+        species_options,
+        "Select the state of the subject and the cell types to add in the circuit",
+        non_interactive=non_interactive,
     )
     return [option.value for option in species_options]
 
@@ -325,7 +337,7 @@ def _filter_simulations_devices(simulations, cell_types):
     return simulations
 
 
-def _configure_simulations(config_simulations):
+def _configure_simulations(config_simulations, non_interactive=False):
     simulation_names = list(
         set(
             [
@@ -346,7 +358,9 @@ def _configure_simulations(config_simulations):
         ),
     ]
     print_panel(
-        simulator_options, "Select the simulations(s) that you want your circuit to perform"
+        simulator_options,
+        "Select the simulations(s) that you want your circuit to perform",
+        non_interactive=non_interactive,
     )
     return simulator_options[0].value
 
@@ -374,6 +388,7 @@ def _configure_sim_params(
     simulation_names,
     micro_params: MicrozonesParams,
     circuit_cell_types: list,
+    non_interactive=False,
 ):
     dict_sim = {"simulations": {}}
     choices = {}
@@ -403,6 +418,7 @@ def _configure_sim_params(
         print_panel(
             [cell_model_option],
             f"Select the neuron model to use during the simulation {sim_name}.",
+            non_interactive=non_interactive,
         )
         cell_model_config = copy.deepcopy(
             config_simulations[simulator]["cell_models"][cell_model_option.value]
@@ -423,6 +439,7 @@ def _configure_sim_params(
         print_panel(
             [conn_model_option],
             f"Select the synapse model to use during the simulation {sim_name}.",
+            non_interactive=non_interactive,
         )
 
         # Rename chosen *_connection_models key → connection_models, drop the rest
@@ -517,7 +534,7 @@ def _clear_unnecessary_params(configuration):
     return configuration
 
 
-def _write_config(configuration, output_folder, extension):
+def _write_config(configuration, output_folder, extension, non_interactive=False):
     output_options = []
     if output_folder is None:
         output_options.append(
@@ -546,6 +563,7 @@ def _write_config(configuration, output_folder, extension):
         print_panel(
             output_options,
             "Configure the folder in which to put the configuration file and its extension.",
+            non_interactive=non_interactive,
         )
         output_folder = output_folder or output_options[0].value
         extension = extension or output_options[-1].value
@@ -628,11 +646,20 @@ def build_nestml(model_dir=None, build_dir=None, module_name=None):
     is_flag=True,
     help="Split your circuit into 2 separated microzones.",
 )
+@click.option(
+    "--non-interactive",
+    "non_interactive",
+    required=False,
+    is_flag=True,
+    help="Skip every interactive prompt and use the default value for anything not given "
+    "through the other options above.",
+)
 def configure(
     species: str = None,
     output_folder: str = None,
     extension: str = None,
     microzones: bool = False,
+    non_interactive: bool = False,
 ):
     """
     Resolve a canonical cerebellum configuration file for BSB based on user choices.
@@ -641,10 +668,12 @@ def configure(
     :param str output_folder: path where to write the output configuration file.
     :param str extension: extension for the configuration file.
     :param bool microzones: whether to split the circuit into microzones.
+    :param bool non_interactive: whether to skip every interactive prompt and use default
+        values for anything not given through the other parameters.
     """
     # Step 1: Species choice
     if species is None:
-        species = _configure_species(species)
+        species = _configure_species(species, non_interactive=non_interactive)
     else:
         print(f"Species chosen: {species}")
     species_folder = join(CONFIGURATION_FOLDER, species)
@@ -656,7 +685,7 @@ def configure(
 
     config_cell_types = load_configs_in_folder(join(species_folder, "cell_types"))
     state, cell_types, microzones = _configure_cell_types(
-        species_folder, config_cell_types, microzones
+        species_folder, config_cell_types, microzones, non_interactive=non_interactive
     )
     configuration = _update_cell_types(configuration, cell_types, config_cell_types)
     state_folder = join(species_folder, state)
@@ -679,7 +708,7 @@ def configure(
         }
         for simulator in get_folders_in_folder(state_folder)
     }
-    simulation_names = _configure_simulations(config_simulations)
+    simulation_names = _configure_simulations(config_simulations, non_interactive=non_interactive)
 
     # Step 4: Simulation models choice
     dict_sim, sim_choices = _configure_sim_params(
@@ -687,6 +716,7 @@ def configure(
         simulation_names,
         micro_params,
         list(configuration["cell_types"].keys()),
+        non_interactive=non_interactive,
     )
     deep_update(configuration, dict_sim)
 
@@ -709,4 +739,4 @@ def configure(
         print(f"\t\tSynapse model: {choices[1]}")
     print("----------------------------\n")
     # Step 7: output folder and extension
-    _write_config(configuration, output_folder, extension)
+    _write_config(configuration, output_folder, extension, non_interactive=non_interactive)

--- a/cerebellar_models/cli.py
+++ b/cerebellar_models/cli.py
@@ -1,6 +1,13 @@
 import copy
 import json
 import os
+
+# Pin a non-interactive backend here, before anything gets a chance to
+# `import matplotlib`, so that inheriting an interactive `MPLBACKEND` from the
+# parent shell can't crash it. This notably happens when running from a Jupyter
+# Colab notebook
+os.environ["MPLBACKEND"] = "Agg"
+
 from collections import OrderedDict
 from enum import Enum
 from os.path import abspath, join

--- a/cerebellar_models/cli.py
+++ b/cerebellar_models/cli.py
@@ -609,6 +609,10 @@ def build_nestml(model_dir=None, build_dir=None, module_name=None):
     Deletes any previously cached build and re-runs PyNESTML code generation and
     installation, equivalent to calling _build_nest_models(redo=True).
     """
+    # Importing `build_models` normally auto-builds/deploys `cerebmodule` as a side effect.
+    # We're about to force a full rebuild right below anyway, so skip that auto-build here to
+    # avoid compiling the models twice in a row.
+    os.environ["_CEREBELLAR_MODELS_SKIP_AUTOBUILD"] = "1"
     from cerebellar_models.nest_models.build_models import _build_nest_models
 
     kwargs = {"redo": True}

--- a/cerebellar_models/nest_models/build_models.py
+++ b/cerebellar_models/nest_models/build_models.py
@@ -34,11 +34,11 @@ def _check_nest_is_buildable(module_name):
     """
     import nest
 
-    if "build_info" in dir(nest):
+    if "build_info" in dir(nest):  # pragma: nocover
         nest_path = nest.build_info["prefix"]
     else:
         nest_path = nest.ll_api.sli_func("statusdict/prefix ::")
-    if not isdir(nest_path):
+    if not isdir(nest_path):  # pragma: nocover
         raise RuntimeError(
             f"Cannot build the '{module_name}' NEST extension module: the NEST "
             f"install prefix reported by `nest` ('{nest_path}') does not exist on "

--- a/cerebellar_models/nest_models/build_models.py
+++ b/cerebellar_models/nest_models/build_models.py
@@ -1,3 +1,4 @@
+import os
 import shutil
 from os import makedirs
 from os.path import abspath, dirname, exists, isdir, join
@@ -99,3 +100,13 @@ def _build_nest_models(
                 }
             },
         )
+
+
+# Auto-build/deploy `cerebmodule` the first time this module is imported (e.g. via a BSB
+# `components:` config entry, or NEST-dependent tests) so callers never have to trigger it
+# explicitly. Skipped when the importer (currently only the `build-nestml` CLI command) is
+# about to force a rebuild right after importing anyway, to avoid compiling the models twice
+# in a row; `.pop()` immediately clears the guard so it can't leak into any subprocess spawned
+# afterward and suppress its own auto-build.
+if os.environ.pop("_CEREBELLAR_MODELS_SKIP_AUTOBUILD", None) is None:
+    _build_nest_models()

--- a/cerebellar_models/nest_models/build_models.py
+++ b/cerebellar_models/nest_models/build_models.py
@@ -10,6 +10,47 @@ _cereb_dirs = appdirs.AppDirs("cerebellar_models")
 _cache_path = _cereb_dirs.user_cache_dir
 
 
+def _check_nest_is_buildable(module_name):
+    """
+    Raise a clear error if the installed ``nest`` package cannot be used to build a
+    custom NEST extension module (e.g. the NESTML-compiled models in this package).
+
+    ``pynestml``'s builder locates NEST's headers/libraries through the install
+    prefix reported by ``nest`` (``nest.build_info["prefix"]``) and the
+    ``nest-config`` script found there. The pip-installable ``nest-simulator``
+    wheels bundle a self-contained NEST binary without a real install prefix: the
+    reported prefix is a leftover build-time temp directory from the wheel's CI
+    build, and ``nest-config --includes``/``--libs`` return paths that never
+    existed on the local machine. Building against such a NEST install always
+    fails, so we detect it upfront instead of surfacing pynestml's cryptic
+    ``InvalidPathException``.
+
+    :param str module_name: name of the extension module about to be built, used
+        only to make the error message more informative.
+    :raises RuntimeError: if the detected NEST install prefix does not exist
+        locally, i.e. building a custom extension module is not currently
+        possible with this NEST installation.
+    """
+    import nest
+
+    if "build_info" in dir(nest):
+        nest_path = nest.build_info["prefix"]
+    else:
+        nest_path = nest.ll_api.sli_func("statusdict/prefix ::")
+    if not isdir(nest_path):
+        raise RuntimeError(
+            f"Cannot build the '{module_name}' NEST extension module: the NEST "
+            f"install prefix reported by `nest` ('{nest_path}') does not exist on "
+            "this machine. This usually happens when NEST was installed from the "
+            "'nest-simulator' PyPI wheel (`pip install nest-simulator`), which "
+            "bundles a self-contained NEST binary without a real install prefix "
+            "and does not currently support building custom NESTML extension "
+            "modules (see https://github.com/nest/nest-simulator/issues/3737). "
+            "Install NEST from source, conda-forge, or your system package "
+            "manager instead, and build the extension module in that environment."
+        )
+
+
 def _build_nest_models(
     model_dir=dirname(__file__),
     build_dir=join(_cache_path, "nest_build"),
@@ -36,8 +77,9 @@ def _build_nest_models(
                 nest.ResetKernel()
                 return
             except nest.NESTErrors.DynamicModuleManagementError as e:
-                if "loaded already" in e.message:
+                if "loaded already" in getattr(e, "message", e.args[0]):
                     return
+        _check_nest_is_buildable(module_name)
         if not (exists(model_dir) and isdir(model_dir)):
             raise OSError("Model directory does not exist: {}".format(model_dir))
         if exists(build_dir) and isdir(build_dir):

--- a/cerebellar_models/nest_models/build_models.py
+++ b/cerebellar_models/nest_models/build_models.py
@@ -99,6 +99,3 @@ def _build_nest_models(
                 }
             },
         )
-
-
-_build_nest_models()

--- a/configurations/mouse/in-vitro/nest/basal_vitro.yaml
+++ b/configurations/mouse/in-vitro/nest/basal_vitro.yaml
@@ -3,7 +3,7 @@ packages:
   - bsb~=7.0
   - bsb-nest~=7.0
 components:
-  - cerebellar_models/nest_models/build_models.py
+  - cerebellar_models.nest_models.build_models
 simulations:
   basal_activity:
     simulator: nest

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -20,7 +20,7 @@ Retrieve a canonical circuit configuration
 
 .. code-block:: bash
 
-  cerebellar-models configure [--output_folder <./path>] [--species <mouse>] [--extension <yaml>] [--microzones]
+  cerebellar-models configure [--output_folder <./path>] [--species <mouse>] [--extension <yaml>] [--microzones] [--non-interactive]
 
 This command will construct a BSB configuration file based on the canonical cerebellar circuit
 developed by the DBBS.
@@ -38,6 +38,8 @@ selected by pressing the right arrow and validated with the enter key.
 * ``--output_folder``: Path to the output folder where the configuration will be stored.
 * ``--extension``: File extension for the configuration. Can be either ``json`` or ``yaml``.
 * ``--microzones``: Flag to split your circuit into 2 separated microzones (not set by default).
+* ``--non-interactive``: Skip every interactive form and use the default value for anything
+  not given through the other options above.
 
 .. note::
     When selecting a ``NEST`` simulation via the CLI, the output configuration will also

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -45,17 +45,19 @@ selected by pressing the right arrow and validated with the enter key.
     (see :ref:`NEST paradigms <nest-paradigms>`).
 
 
-Re-compile NESTML neuron models
-================================
+.. _cli-nestml:
+
+Re-compile NESTML models
+========================
 
 .. code-block:: bash
 
   cerebellar-models build-nestml [--model_dir <path>] [--build_dir <path>] [--module_name <name>]
 
-This command forces a full re-compilation of the NESTML neuron models used by the NEST
+This command forces a full re-compilation of the NESTML models used by the NEST
 simulator. It is equivalent to calling ``_build_nest_models(redo=True)`` programmatically:
 the existing build cache is cleared and PyNESTML re-generates the C++ source code and
-reinstalls the NEST module ``cerebmodule``.
+re-installs the NEST module ``cerebmodule``.
 
 Running this command is useful when:
 

--- a/docs/configurations/mouse/nest/nest.rst
+++ b/docs/configurations/mouse/nest/nest.rst
@@ -1,27 +1,8 @@
 NEST simulations
 ----------------
 
-NEST Installation
-^^^^^^^^^^^^^^^^^
-To reproduce the experiments presented below, you should install the NEST simulator (see
-instructions :doc:`here </getting-started/installation>`).
-
-NEST modules are automatically compiled with BSB as ``components`` and deployed as ``cerebmodule``
-through the provided configurations:
-
-.. code-block:: yaml
-
-    components:
-      - cerebellar_models.nest_models.build_models
-    simulations:
-        simulation_name:
-            simulator: nest
-            modules:
-                - cerebmodule
-
-Alternatively, you can manually compile them, running the
-`build_models.py <https://github.com/dbbs-lab/cerebellar-models/blob/master/cerebellar_models/nest_models/build_models.py>`_
-python script.
+To reproduce the experiments presented below, install the NEST simulator and compile the
+NESTML cell models as described in the :doc:`installation guide </getting-started/installation>`.
 
 .. toctree::
     :maxdepth: 2

--- a/docs/getting-started/installation.rst
+++ b/docs/getting-started/installation.rst
@@ -45,6 +45,14 @@ the :doc:`developers' packages <for-developers>`.
 NEST simulator
 ~~~~~~~~~~~~~~
 
+``cerebellar-models`` compiles its own NESTML-based cell models (``cerebellar-models
+build-nestml``) against your NEST installation. This requires a NEST install with a real,
+existing install prefix and its C++ headers available, which not every installation method
+below provides.
+
+From source
+^^^^^^^^^^^
+
 Download and install the NEST simulator in the current folder within your virtual environment:
 
 .. code-block:: bash
@@ -58,7 +66,55 @@ Download and install the NEST simulator in the current folder within your virtua
    # To speed up the process, you can set the number of process to compile NEST, here 4
    make install -j4
 
+NEST 3.9 and later additionally require the Boost headers to build against
+(``libboost-dev`` on Debian/Ubuntu, ``boost`` via Homebrew, ...).
 
+With conda or mamba
+^^^^^^^^^^^^^^^^^^^^
+
+NEST is also available on conda-forge, with a working install prefix that
+``cerebellar-models build-nestml`` can compile against:
+
+.. code-block:: bash
+
+   mamba install -c conda-forge nest-simulator cmake compilers libboost-headers
+
+``libboost-headers`` is required alongside ``nest-simulator``: NEST's conda-forge package only
+depends on Boost at *build* time, so it is not pulled in automatically even though NEST's
+installed headers need it at compile time.
+
+.. warning::
+   Do not use ``pip install nest-simulator``. The PyPI wheel bundles a self-contained NEST
+   binary without a usable install prefix, and its ``nest-config`` script reports hardcoded
+   paths from the wheel's own CI build that do not exist on your machine. As a result,
+   ``cerebellar-models build-nestml`` (and NESTML in general) cannot build custom extension
+   modules against it — see `nest/nest-simulator#3737
+   <https://github.com/nest/nest-simulator/issues/3737>`_. Use the source or conda/mamba routes
+   above instead.
+
+Compiling the NESTML models
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``cerebellar-models`` defines its cell and synapse models in NESTML file format
+and compiles them into a NEST extension module (``cerebmodule``) on top of the
+NEST installation set up above.
+
+This happens automatically the first time it is needed: ``bsb compile``/``bsb simulate`` compile
+and deploy ``cerebmodule`` for you when your configuration lists the
+``cerebellar_models.nest_models.build_models`` component, e.g.:
+
+.. code-block:: yaml
+
+    components:
+      - cerebellar_models.nest_models.build_models
+    simulations:
+        simulation_name:
+            simulator: nest
+            modules:
+                - cerebmodule
+
+Alternatively, you can trigger (or force) the compilation manually with the
+:ref:`cerebellar-models build-nestml <cli-nestml>` CLI command.
 
 What next:
 ~~~~~~~~~~

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,15 +1,16 @@
 [build-system]
-requires = ["flit_core >=3.2,<4"]
-build-backend = "flit_core.buildapi"
+requires = ["hatchling"]
+build-backend = "hatchling.build"
 
 [project]
 name = "cerebellar-models"
 authors = [{ name = "Dimitri RODARIE", email = "dimitri.rodarie@unipv.it" }]
+description = "Implementation of the BSB framework for cerebellar cortex reconstructions and simulations."
 readme = "README.md"
 license = { file = "LICENSE" }
 classifiers = ["License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)"]
 requires-python = ">=3.10"
-dynamic = ["version", "description"]
+dynamic = ["version"]
 dependencies = [
     "bsb[parallel]~=7.0",
     "click~=8.1",
@@ -66,6 +67,23 @@ known_third_party = ["nest"]
 
 [project.entry-points."bsb.components"]
 my_components = "cerebellar_models:classmap"
+
+[tool.hatch.version]
+path = "cerebellar_models/__init__.py"
+
+[tool.hatch.build.targets.wheel]
+packages = ["cerebellar_models"]
+
+# `configurations/` and `morphologies/` live at the repository root (not inside
+# `cerebellar_models/`) so they stay easy to find for contributors and tooling
+# (e.g. `bsb compile configurations/...`). They are copied into the built wheel
+# here so that `pip install cerebellar-models` ships them too; `cli.py` looks for
+# them in both locations to support editable installs, where this copy step does
+# not run and the files stay at their original repository path.
+[tool.hatch.build.targets.wheel.force-include]
+"configurations" = "cerebellar_models/configurations"
+"morphologies" = "cerebellar_models/morphologies"
+"tests/test_configurations/canonical_mouse_awake_io_nest.json" = "cerebellar_models/configurations/canonical_mouse_awake_io_nest.json"
 
 [tool.coverage.run]
 branch = true

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,6 +12,7 @@ from click.testing import CliRunner
 from cerebellar_models.cli import (
     CerebOption,
     TypeTermElem,
+    _absolutize_morphology_paths,
     _filter_simulations_devices,
     _get_compatible_models,
     _update_cell_types,
@@ -228,6 +229,9 @@ class TestCli(unittest.TestCase):
         config2 = parse_configuration_file(
             join(folder, "test_configurations/canonical_mouse_awake_io_nest.json")
         ).__tree__()
+        # The fixture keeps relative morphology paths for portability across machines;
+        # apply the same absolutization the CLI performs before comparing.
+        config2 = _absolutize_morphology_paths(config2)
         runner = CliRunner()
         result = runner.invoke(
             configure,
@@ -281,6 +285,9 @@ class TestCli(unittest.TestCase):
         config2 = parse_configuration_file(
             join(folder, "test_configurations/canonical_mouse_awake_io_nest.json")
         ).__tree__()
+        # The fixture keeps relative morphology paths for portability;
+        # apply the same absolutization the CLI performs before comparing.
+        config2 = _absolutize_morphology_paths(config2)
         runner = CliRunner()
         result = runner.invoke(configure, ["--non-interactive"])
         self.assertEqual(result.exit_code, 0, result.output)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -29,7 +29,7 @@ def deep_equal(d, u, path="/"):
     return True
 
 
-def mock_print_panel(options, title="test"):
+def mock_print_panel(options, title="test", non_interactive=False):
     return
 
 
@@ -179,7 +179,7 @@ class TestCli(unittest.TestCase):
 
     @patch(
         "cerebellar_models.cli.print_panel",
-        lambda options, title: mock_print_panel(options, title),
+        lambda options, title, **kwargs: mock_print_panel(options, title, **kwargs),
     )
     def test_configure_errors(self):
         runner = CliRunner()
@@ -221,7 +221,7 @@ class TestCli(unittest.TestCase):
 
     @patch(
         "cerebellar_models.cli.print_panel",
-        lambda options, title: mock_print_panel(options, title),
+        lambda options, title, **kwargs: mock_print_panel(options, title, **kwargs),
     )
     def test_configure(self):
         folder = dirname(__file__)
@@ -257,7 +257,7 @@ class TestCli(unittest.TestCase):
 
     @patch(
         "cerebellar_models.cli.print_panel",
-        lambda options, title: mock_print_panel(options, title),
+        lambda options, title, **kwargs: mock_print_panel(options, title, **kwargs),
     )
     def test_configure_no_microzones(self):
         runner = CliRunner()
@@ -270,9 +270,27 @@ class TestCli(unittest.TestCase):
         self.assertNotIn("after_placement", config)
         os.remove("./circuit.yaml")
 
+    def test_configure_non_interactive(self):
+        """``--non-interactive`` must skip the survey entirely and fall back to defaults,
+        without patching ``print_panel`` itself. Note: this deliberately does *not* mock
+        ``survey`` — if ``non_interactive`` failed to skip it, ``survey`` would try to set up
+        real terminal I/O and crash under pytest's captured stdin, the same class of failure
+        reported from Colab's non-tty stdin.
+        """
+        folder = dirname(__file__)
+        config2 = parse_configuration_file(
+            join(folder, "test_configurations/canonical_mouse_awake_io_nest.json")
+        ).__tree__()
+        runner = CliRunner()
+        result = runner.invoke(configure, ["--non-interactive"])
+        self.assertEqual(result.exit_code, 0, result.output)
+        config = parse_configuration_file("./circuit.yaml").__tree__()
+        self.assertTrue(deep_equal(config, config2))
+        os.remove("./circuit.yaml")
+
     @patch(
         "cerebellar_models.cli.print_panel",
-        lambda options, title: mock_print_panel(options, title),
+        lambda options, title, **kwargs: mock_print_panel(options, title, **kwargs),
     )
     def test_configure_json_extension(self):
         runner = CliRunner()

--- a/tests/test_configurations/canonical_mouse_awake_io_nest.json
+++ b/tests/test_configurations/canonical_mouse_awake_io_nest.json
@@ -20,7 +20,7 @@
     },
     "components": [
         {
-            "module": "cerebellar_models/nest_models/build_models.py"
+            "module": "cerebellar_models.nest_models.build_models"
         }
     ],
     "morphologies": [


### PR DESCRIPTION
## Describe the work done
Make sure that the `cerebellar-models` package can be leveraged from any computer without having to clone it or copy configurations and morphologies. Now can be used in Google Colab.  

- Add `configurations` and `morphologies` folder to the built package (change `pyproject.toml` from `flit_core` to `hatchling`
- Adapt the CLI so that the path to the `morphologies` and `configurations` depends on if the package in built or cloned from repo.
- Add safe guards for installations of NEST that don't work with NESTML (e.g., from `pip install`)
- Improve documentation on how to compile NESTML models
- Add flag for CLI `configure` command to skip the display and use default params.
- Skip double compilation of NESTML models when using the CLI
- Use dotted paths instead of regular path for BSB components (more 
- Make paths to `morphologies` absolute when generating configurations. Helps in case configurations are not generated in the folder they are planned to be used.

## Tasks

* [x] Updated documentation

<!-- readthedocs-preview cerebellar-models start -->
----
📚 Documentation preview 📚: https://cerebellar-models--82.org.readthedocs.build/en/82/

<!-- readthedocs-preview cerebellar-models end -->